### PR TITLE
Agregada funcionalidad para introducir mas de un archivo

### DIFF
--- a/excel_to_json.rb
+++ b/excel_to_json.rb
@@ -24,30 +24,33 @@ attributes = {
 	logo: 'logo'
 }
 
-#Lee el nombre del archivo desde la consola
-xlsx_name = ARGV[0]
-#Obtiene el nombre del archivo sin extension
-json_name = File.basename( xlsx_name, ".*" )
-#Crea un archivo json vacio
-json_name = json_name+'.json'
-FileUtils.touch(json_name)
+ARGV.each do |i|
+	#Lee el nombre del archivo desde la consola
+	xlsx_name = i
+	#Obtiene el nombre del archivo sin extension
+	json_name = File.basename( xlsx_name, ".*" )
+	#Crea un archivo json vacio
+	json_name = json_name+'.json'
+	FileUtils.touch(json_name)
 
-#Abre el archivo excel.
-book = Roo::Spreadsheet.open(xlsx_name)
-sheet = book.sheet(0)
-count = 1
+	#Abre el archivo excel.
+	book = Roo::Spreadsheet.open(xlsx_name)
+	sheet = book.sheet(0)
+	count = 1
 
-File.open(json_name, "w") do |f|
-	f.write("[")
-	sheet.each(attributes) do |hash|
-		if(count > 1)
-			f.write(JSON.pretty_generate(hash))
-			if(count < sheet.last_row)
-				f.write(",")
+	File.open(json_name, "w") do |f|
+		f.write("[")
+		sheet.each(attributes) do |hash|
+			if(count > 1)
+				f.write(JSON.pretty_generate(hash))
+				if(count < sheet.last_row)
+					f.write(",")
+				end
+				f.write("\n")
 			end
-			f.write("\n")
+			count += 1
 		end
-		count += 1
+		f.write("]")
 	end
-	f.write("]")
 end
+

--- a/test.json
+++ b/test.json
@@ -357,4 +357,5 @@
   "metrics": "- Less than 20% cost of online tutoring\n- 1.000+ beta sign ups\n- Acceptance / participation in 4 accelerators last 12 months",
   "investment_looking_raise": "50 - 200K USD in convertible notes",
   "logo": "word-up.png"
-}]
+}
+]


### PR DESCRIPTION
En la linea de comandos puedes pasarle mas de un archivo, permitiendo el uso de globs y demases. 

Ejemplo:

```
    $ ruby excel_to_json *.xlsx
```

Eso convierte todos los archivos excel dentro de la carpeta en JSON.
También le cambié el nombre de demoday a test, ya que creo se hace más entendible. Lo puede revertir si quieres.
